### PR TITLE
Refactored Electron UIA-related components

### DIFF
--- a/addon/doc/zh_CN/readme.md
+++ b/addon/doc/zh_CN/readme.md
@@ -18,6 +18,13 @@
 
 ## 更新日志
 
+### v0.9.0
+
+* 重构 Electron UIA 相关部分：
+  * 使用 `IUIAutomation.ElementFromPointBuildCache` 方法从坐标获取 UIA 元素，用于创建重定向的鼠标对象。
+  * 同时使用 `IUIAutomationCondition` 排除 `Name` 属性为空字符串的 UIA 元素，以修复鼠标导航 VS Code 时的一些问题。
+    * 例如现在可以读取悬浮面板上的文本。
+
 ### v0.8.4
 
 * 重构“强制使用应用程序的 UIA 实现”的判断逻辑，并排除 Chrome 浏览器侧边栏扩展对 Chrome 浏览器的影响。

--- a/buildVars.py
+++ b/buildVars.py
@@ -30,11 +30,14 @@ Experimental fix for mouse tracking in WinUI apps.
 WinUI applications: e.g. Windows Terminal, PowerToys v0.86.0 and higher, some applications that come with Windows, etc.
 Automatically update the mouse object."""),
 	# version
-	addon_version="0.8.4",
+	addon_version="0.9.0",
 	# Brief changelog for this version
 	# Translators: what's new content for the add-on version to be shown in the add-on store
 	addon_changelog=_(
-		"""* Refactor the "force use of the application's UIA implementation" judgment logic and exclude Chrome's sidebar extensions from affecting Chrome."""
+		"""* Refactored Electron UIA-related components:
+  * Utilized the `IUIAutomation.ElementFromPointBuildCache` method to retrieve UIA elements from coordinates for creating redirected mouse objects.
+  * Simultaneously employed `IUIAutomationCondition` to exclude UIA elements with an empty `Name` attribute, resolving certain issues encountered during mouse navigation in VS Code.
+    * For example it is now possible to read the text on the hover panel."""
 	),
 	# Author(s)
 	addon_author="hwf1324 <1398969445@qq.com>",

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
-# v0.8.4
+# v0.9.0
 
-* Refactor the "force use of the application's UIA implementation" judgment logic and exclude Chrome's sidebar extensions from affecting Chrome.
+* Refactored Electron UIA-related components:
+  * Utilized the `IUIAutomation.ElementFromPointBuildCache` method to retrieve UIA elements from coordinates for creating redirected mouse objects.
+  * Simultaneously employed `IUIAutomationCondition` to exclude UIA elements with an empty `Name` attribute, resolving certain issues encountered during mouse navigation in VS Code.
+    * For example it is now possible to read the text on the hover panel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,31 @@ ignore = [
 # so ignore F821.
 "sconstruct" = ["F821"]
 
+[tool.ty.environment]
+python = "../nvda/.venv"
+# Tailor type stubs and conditionalized type definitions to windows.
+python-platform = "win32"
+root = ["./addon"]
+# Tell ty where to load python code from
+extra-paths = [
+	"./addon",
+	"../nvda/source",
+]
+
+[tool.ty.src]
+include = [
+	"**/*.py",
+]
+
+exclude = [
+	"sconstruct",
+	".git",
+	"__pycache__",
+	# When excluding concrete paths relative to a directory,
+	# not matching multiple folders by name e.g. `__pycache__`,
+	# paths are relative to the configuration file.
+]
+
 [tool.pyright]
 pythonPlatform = "Windows"
 typeCheckingMode = "strict"

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,13 @@ Some features may be moved out as standalone features in the future.
 
 ## Changelog
 
+### v0.9.0
+
+* Refactored Electron UIA-related components:
+  * Utilized the `IUIAutomation.ElementFromPointBuildCache` method to retrieve UIA elements from coordinates for creating redirected mouse objects.
+  * Simultaneously employed `IUIAutomationCondition` to exclude UIA elements with an empty `Name` attribute, resolving certain issues encountered during mouse navigation in VS Code.
+    * For example it is now possible to read the text on the hover panel.
+
 ### v0.8.4
 
 * Refactor the "force use of the application's UIA implementation" judgment logic and exclude Chrome's sidebar extensions from affecting Chrome.


### PR DESCRIPTION
* Utilized the `IUIAutomation.ElementFromPointBuildCache` method to retrieve UIA elements from coordinates for creating redirected mouse objects.
  * Simultaneously employed `IUIAutomationCondition` to exclude UIA elements with an empty `Name` attribute, resolving certain issues encountered during mouse navigation in VS Code.
    * For example it is now possible to read the text on the hover panel.